### PR TITLE
Fix compilation failure under newer versions of Openwrt

### DIFF
--- a/ku-ua/Makefile
+++ b/ku-ua/Makefile
@@ -9,7 +9,8 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=ku-ua
-PKG_RELEASE:=4.7
+PKG_VERSION:=4.8
+PKG_RELEASE:=1
 
 include $(INCLUDE_DIR)/package.mk
 


### PR DESCRIPTION
1. Fix compilation failure due to missing of PKG_VERSION in newer versions of Openwrt using apk package manager.
2. Upgrade version number to 4.8